### PR TITLE
Remove localStorage timer when cleaning the timer

### DIFF
--- a/assets/middlewares/timer.ts
+++ b/assets/middlewares/timer.ts
@@ -32,6 +32,7 @@ function cleanTimer () {
   header.style.removeProperty("--progress")
   headerText.innerHTML = ""
   headerText.removeEventListener('click', cleanTimer)
+  localStorage.removeItem(storageKey)
   if (timeout) {
     clearTimeout(timeout)
     timeout = null


### PR DESCRIPTION
Hello Grafikart,

I found an issue using the timer. When I click on the timer to cancel it, and I refresh the page, the timer is back. I think you forget to clean the localStorage item when removing the timer.
This pull request fix this.

Best regards.