### PR TITLE
[INSTALL] Ajout du support de windows

### DIFF
--- a/install.go
+++ b/install.go
@@ -61,6 +61,26 @@ func installApp() error {
 			fmt.Println("Pour le désactiver :")
 			color.Blue("systemctl disable --user grafisearch.service")
 		}
+	case "windows":
+		// https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/new-service?view=powershell-7.2
+		// Require admin right | Possible solution : Start-Process [...] -Verbs RunAs
+		serviceName := "GrafiSearch"
+		var execPath string
+		execPath, err = getCurrentExecPath()
+		command := fmt.Sprintf("New-Service -Name %s -BinaryPathName %s -StartupType Automatic", serviceName, execPath)
+		_, err = exec.Command("powershell.exe", command).Output()
+		if err == nil {
+			color.Green("Le service a été ajouté avec le nom %s et activé %s !\n", serviceName, execPath)
+			fmt.Println("")
+			fmt.Println("Pour le démarrer :")
+			color.Blue("Start-Service -Name %s", serviceName)
+			fmt.Println("")
+			fmt.Println("Pour le désactiver :")
+			color.Blue("Stop-Service -Name %s", serviceName)
+			fmt.Println("")
+			fmt.Println("Pour le supprimer :")
+			color.Blue("Remove-Service -Name %s", serviceName)
+		}
 	default:
 		return fmt.Errorf("système d'exploitation non géré %s", runtime.GOOS)
 	}


### PR DESCRIPTION
Le but a terme est de pouvoir facilement installer le service sous Windows également.

Pour cela, j'utilise la commande `New-Service` disponible sous Powershell.
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/new-service?view=powershell-7.2 .

Cependant, la commande nécessite deux prérequis pour fonctionner pour le moment:

* Avoir un "Execution Policy" valide : Voir [`Set-ExecutionPolicy`](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7.2) pour plus d'information | Normalement c'est déjà le cas si le PC est en mode [développeur](https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development)
* Exécuter la commande en Administrateur : Peut potentiellement être bypass avec la commande [`Start-Process [...] -Verb RunAs`](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/start-process?view=powershell-7.2) qui utilise l'UAC de Windows pour l'élévation de privilège