### PR TITLE
feat: add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.18-alpine AS builder
+
+# Copy files
+WORKDIR /app
+COPY ./ ./
+
+# Node.js
+RUN apk add --update nodejs npm
+RUN npm install
+RUN npm run build
+
+# Go
+RUN go mod download
+RUN go build -o /grafisearch
+
+# Build image
+FROM alpine:latest
+
+COPY --from=builder /grafisearch /
+
+CMD [ "/grafisearch" ]

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "prettier": "^2.6.2",
-    "sass": "^1.49.11",
-    "typescript": "^4.5.4",
-    "vite": "^2.9.0"
+    "prettier": "^2.8.3",
+    "sass": "^1.57.1",
+    "typescript": "^4.9.4",
+    "vite": "^4.0.4"
   },
   "dependencies": {
-    "@types/node": "^17.0.23"
+    "@types/node": "^18.11.18"
   }
 }


### PR DESCRIPTION
Ajout du support de Docker en construisant une image finale légère (18MB).

Exemple d'utilisation sur le port 8000 : 
```
docker build -t grafisearch .
docker run -p 8000:8042 -v $PWD/stats.csv:/root/grafisearch.csv grafisearch
```